### PR TITLE
Feature/match card game stats

### DIFF
--- a/src/api/mapper/mapper.ts
+++ b/src/api/mapper/mapper.ts
@@ -1,3 +1,4 @@
+import type { Json } from "@/types/supabase.types";
 import type {
   StudySetRow,
   StudySetWithCard,
@@ -7,10 +8,7 @@ import type {
   StudyFolderSetInsert,
   StudyFolderSetRelations,
 } from "@/api/repository/studyFolderSet.repository";
-import type {
-  StudyMatchGameSessionInsert,
-  StudyMatchGameSessionRow,
-} from "@/api/repository/studyMatchGameSession.repository";
+import type { StudyMatchGameSessionInsert } from "@/api/repository/studyMatchGameSession.repository";
 import type {
   StudyCardDraft,
   StudyFolderSummary,
@@ -19,6 +17,7 @@ import type {
   StudySetSummary,
   UserProfile,
   StudyMatchGameSessionSummary,
+  StudyMatchGameStats,
 } from "@/api/mapper/types";
 import type { StudyCardRow } from "@/api/repository/studyCard.repository";
 import type { StudyFolderRow } from "@/api/repository/studyFolder.repository";
@@ -162,5 +161,29 @@ export function toSetDetail(row: StudySetWithCard): StudySetDetail {
     description: row.description ?? null,
     isPublic: row.is_public!,
     cards,
+  };
+}
+
+export function toMatchCardGameStats(json: Json): StudyMatchGameStats {
+  if (!json || typeof json !== "object") {
+    throw new Error("invalid stats result");
+  }
+  const data = json as Record<string, unknown>;
+
+  return {
+    avgTime: Number(data.avg_time ?? 0),
+    firstTime: Number(data.first_time ?? 0),
+    lastTime: Number(data.last_time ?? 0),
+    timeDiffPercent: Number(data.time_diff_percent ?? 0),
+    improvementPercent:
+      data.improvement_percent !== null
+        ? Number(data.improvement_percent)
+        : null,
+    accuracy: Number(data.accuracy ?? 0),
+    efficiency: Number(data.efficiency ?? 0),
+    totalAttempts: Number(data.total_attempts ?? 0),
+    totalCorrect: Number(data.total_correct ?? 0),
+    totalWrong: Number(data.total_wrong ?? 0),
+    totalSessions: Number(data.total_sessions ?? 0),
   };
 }

--- a/src/api/mapper/types.ts
+++ b/src/api/mapper/types.ts
@@ -80,3 +80,17 @@ export type StudyMatchGameSessionSummary = {
   correctMatches: number;
   wrongMatches: number;
 };
+
+export type StudyMatchGameStats = {
+  avgTime: number;
+  firstTime: number;
+  lastTime: number;
+  timeDiffPercent: number;
+  improvementPercent: number | null;
+  accuracy: number;
+  efficiency: number;
+  totalAttempts: number;
+  totalCorrect: number;
+  totalWrong: number;
+  totalSessions: number;
+};

--- a/src/api/repository/studyMatchGameSession.repository.ts
+++ b/src/api/repository/studyMatchGameSession.repository.ts
@@ -16,14 +16,11 @@ export const studyMatchGameSessionRepository = {
       .single();
     return sbExecOne(studyMatchGameSessionBuilder);
   },
-  findBySetIdAndUserId: (setId: string, userId: string) => {
-    const studyMatchGameSessionBuilder = supabase
-      .from("study_match_game_session")
-      .select("*")
-      .eq("set_id", setId)
-      .eq("user_id", userId)
-      .select()
-      .single();
+  findStatsBySetIdAndUserId: (setId: string, userId: string) => {
+    const studyMatchGameSessionBuilder = supabase.rpc("get_match_game_stats", {
+      user_uuid: userId,
+      set_uuid: setId,
+    });
     return studyMatchGameSessionBuilder;
   },
 };

--- a/src/api/study-match-game-session.api.ts
+++ b/src/api/study-match-game-session.api.ts
@@ -9,5 +9,8 @@ export async function insertStudyMatchGameSession(
 }
 
 export async function getStudyMatchGameSession(setId: string, userId: string) {
-  return studyMatchGameSessionRepository.findBySetIdAndUserId(setId, userId);
+  return studyMatchGameSessionRepository.findStatsBySetIdAndUserId(
+    setId,
+    userId
+  );
 }

--- a/src/components/studyroom/match-card-stats.tsx
+++ b/src/components/studyroom/match-card-stats.tsx
@@ -1,0 +1,112 @@
+import { ChartBar } from "lucide-react";
+import { generateFeedback } from "@/utils/feedback";
+import { useMatchCardSessionQuery } from "@/hooks/queries/useMatchCardSessionQuery";
+
+type MatchCardStatsProps = {
+  setId: string;
+  userId: string;
+};
+function MatchCardStats({ setId, userId }: MatchCardStatsProps) {
+  const {
+    data: stats,
+    isLoading,
+    isError,
+  } = useMatchCardSessionQuery(userId, setId);
+
+  if (isLoading) {
+    return (
+      <div className="bg-white rounded-xl shadow p-6 mb-6">
+        <h3 className="text-lg font-semibold mb-4 flex gap-3">
+          <ChartBar /> 카드 맞추기 요약
+        </h3>
+        <p className="text-slate-500">통계를 불러오는 중...</p>
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="bg-white rounded-xl shadow p-6 mb-6">
+        <h3 className="text-lg font-semibold mb-4 flex gap-3">
+          <ChartBar /> 카드 맞추기 요약
+        </h3>
+        <p className="text-red-500">통계를 불러오지 못했습니다.</p>
+      </div>
+    );
+  }
+
+  if (!stats || stats.totalSessions === 0) {
+    return (
+      <div className="bg-white rounded-xl shadow p-6 mb-6">
+        <h3 className="text-lg font-semibold mb-4 flex gap-3">
+          <ChartBar /> 카드 맞추기 요약
+        </h3>
+        <p className="text-slate-500">
+          아직 카드 맞추기 기록이 없으시군요? 카드 맞추기 게임을 통해
+          학습해보세요!
+        </p>
+      </div>
+    );
+  }
+
+  const feedbacks = generateFeedback(stats);
+
+  return (
+    <div className="bg-white rounded-xl shadow p-6 mb-6">
+      <h3 className="text-lg font-semibold mb-4 flex gap-3">
+        <ChartBar /> 카드 맞추기 요약
+      </h3>
+      {/* 피드백 */}
+      <div className="bg-slate-50 p-3 rounded-lg text-sm mb-4">
+        {feedbacks.slice(0, 2).map((msg: string, i: number) => (
+          <p key={i} className="mb-1">
+            💡 {msg}
+          </p>
+        ))}
+      </div>
+      <div className="grid grid-cols-2 gap-4 mb-4 text-sm">
+        {/* 총 세션 */}
+        <div>
+          <p className="text-slate-500">총 세션</p>
+          <p className="font-bold">{stats.totalSessions ?? 0}회</p>
+        </div>
+
+        {/* 평균 시간 */}
+        <div>
+          <p className="text-slate-500">평균 시간</p>
+          <p className="font-bold">{stats.avgTime ?? 0}초</p>
+        </div>
+
+        {/* 정답률 */}
+        <div className="col-span-2">
+          <p className="text-slate-500">정답률</p>
+          <div className="flex items-center gap-2">
+            <div className="w-full bg-slate-200 rounded-full h-2">
+              <div
+                className="bg-green-500 h-2 rounded-full"
+                style={{ width: `${stats.accuracy ?? 0}%` }}
+              />
+            </div>
+            <span className="font-bold">{stats.accuracy ?? 0}%</span>
+          </div>
+        </div>
+
+        {/* 효율 */}
+        <div>
+          <p className="text-slate-500">효율</p>
+          <p className="font-bold">
+            {stats.efficiency ? `${stats.efficiency}개/초` : "-"}
+          </p>
+        </div>
+
+        {/* 총 시도 */}
+        <div>
+          <p className="text-slate-500">총 시도</p>
+          <p className="font-bold">{stats.totalAttempts ?? 0}회</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default MatchCardStats;

--- a/src/hooks/queries/keys.ts
+++ b/src/hooks/queries/keys.ts
@@ -32,3 +32,9 @@ export const profileKeys = {
   all: ["user"] as const,
   detail: (userId: string) => [...profileKeys.all, "detail", userId] as const,
 };
+
+export const matchCardSessionKeys = {
+  all: ["matchCardSession"] as const,
+  stats: (userId: string, setId: string) =>
+    [...matchCardSessionKeys.all, "stats", userId, setId] as const,
+};

--- a/src/hooks/queries/useMatchCardSessionQuery.ts
+++ b/src/hooks/queries/useMatchCardSessionQuery.ts
@@ -1,0 +1,19 @@
+import { useQuery } from "@tanstack/react-query";
+import { getStudyMatchGameSession } from "@/api/study-match-game-session.api";
+import { matchCardSessionKeys } from "@/hooks/queries/keys";
+import type { Json } from "@/types/supabase.types";
+import { toMatchCardGameStats } from "@/api/mapper/mapper";
+
+export function useMatchCardSessionQuery(userId: string, setId: string) {
+  return useQuery({
+    queryKey: matchCardSessionKeys.stats(userId, setId),
+    enabled: !!userId && !!setId,
+    queryFn: async () => {
+      if (!userId || !setId) return {};
+      const res = await getStudyMatchGameSession(setId, userId);
+      if (res.error) throw res.error;
+      return res.data ?? {};
+    },
+    select: (row: Json) => toMatchCardGameStats(row),
+  });
+}

--- a/src/pages/studyroom/main.tsx
+++ b/src/pages/studyroom/main.tsx
@@ -8,15 +8,19 @@ import LearnFlashcard from "@/components/card/learn-flashcards";
 import PageWrapper from "@/components/layout/page-wrapper";
 import PageHeader from "@/components/layout/page-header";
 import LoadingSpinner from "@/components/ui/loading";
+import MatchCardStats from "@/components/studyroom/match-card-stats";
+import { useAuthStore } from "@/store/useAuthStore";
+
 const Main = () => {
   const { setId } = useParams();
   const { data: studySet, isLoading } = useSetWithCardsQuery(setId);
+  const userId = useAuthStore((state) => state.user?.id);
 
   if (isLoading) {
     return <LoadingSpinner fullScreen={true} />;
   }
 
-  if (!setId) {
+  if (!setId || !userId) {
     return <Navigate to="/library" />;
   }
 
@@ -30,9 +34,11 @@ const Main = () => {
         <LearnFlashcard cards={cards} setId={setId} />
       </section>
       <section>
-        <h3 className="text-xl font-bold mb-4">
-          이 세트의 단어({cards.length})
-        </h3>
+        <h3 className="section-title">나만의 학습 기록</h3>
+        <MatchCardStats setId={setId} userId={userId} />
+      </section>
+      <section>
+        <h3 className="section-title">이 세트의 단어({cards.length})</h3>
         <div className="bg-secondary p-5 rounded-2xl">
           <div className="flex flex-col gap-4 w-full">
             {cards.map((card) => (

--- a/src/styles/style.css
+++ b/src/styles/style.css
@@ -101,8 +101,16 @@
     @apply bg-gray-200 animate-pulse rounded;
   }
 
+  .match-card {
+    @apply flex items-center justify-center w-full h-full p-2 text-center rounded-lg shadow-md cursor-pointer transition-all duration-300 transform-gpu border-2 overflow-hidden;
+  }
+
   .error-card {
     animation: tilt-shaking 0.2s infinite;
+  }
+
+  .section-title {
+    @apply md:text-xl font-bold mb-4 flex gap-3;
   }
 }
 

--- a/src/types/supabase.types.ts
+++ b/src/types/supabase.types.ts
@@ -385,6 +385,10 @@ export type Database = {
           user_name: string
         }[]
       }
+      get_match_game_stats: {
+        Args: { set_uuid: string; user_uuid: string }
+        Returns: Json
+      }
     }
     Enums: {
       [_ in never]: never

--- a/src/utils/feedback.ts
+++ b/src/utils/feedback.ts
@@ -18,18 +18,20 @@ export const generateFeedback = (stats: StudyMatchGameStats): string[] => {
   }
 
   // 2. 속도 관련
-  if (stats.timeDiffPercent > 0) {
-    messages.push(
-      `⏱️ 첫 세션(${stats.firstTime}초)보다 마지막 세션(${stats.lastTime}초)이 ${stats.timeDiffPercent}% 빨라졌습니다.`
-    );
-  } else if (stats.timeDiffPercent < 0) {
-    messages.push(
-      `🐢 첫 세션(${stats.firstTime}초) 대비 마지막 세션(${
-        stats.lastTime
-      }초)은 ${Math.abs(stats.timeDiffPercent)}% 느려졌습니다.`
-    );
-  } else {
-    messages.push(`⚖️ 첫 세션과 마지막 세션의 소요 시간이 비슷합니다.`);
+  if (stats.totalSessions > 1) {
+    if (stats.timeDiffPercent > 0) {
+      messages.push(
+        `⏱️ 첫 세션(${stats.firstTime}초)보다 마지막 세션(${stats.lastTime}초)이 ${stats.timeDiffPercent}% 빨라졌습니다.`
+      );
+    } else if (stats.timeDiffPercent < 0) {
+      messages.push(
+        `🐢 첫 세션(${stats.firstTime}초) 대비 마지막 세션(${
+          stats.lastTime
+        }초)은 ${Math.abs(stats.timeDiffPercent)}% 느려졌습니다.`
+      );
+    } else {
+      messages.push(`⚖️ 첫 세션과 마지막 세션의 소요 시간이 비슷합니다.`);
+    }
   }
 
   // 3. 직전 대비 개선율

--- a/src/utils/feedback.ts
+++ b/src/utils/feedback.ts
@@ -1,0 +1,63 @@
+import type { StudyMatchGameStats } from "@/api/mapper/types";
+export const generateFeedback = (stats: StudyMatchGameStats): string[] => {
+  const messages: string[] = [];
+
+  // 1. 정확도 관련
+  if (stats.accuracy === 100) {
+    messages.push(
+      `🎯 ${stats.totalAttempts}번 시도 중 ${stats.totalCorrect}개를 모두 맞췄습니다. 정확도가 매우 뛰어납니다.`
+    );
+  } else if (stats.accuracy >= 80) {
+    messages.push(
+      `✅ 정답률은 ${stats.accuracy}%로 높은 편입니다. 틀린 문제는 ${stats.totalWrong}개입니다.`
+    );
+  } else {
+    messages.push(
+      `⚠️ 정답률은 ${stats.accuracy}%에 머물렀습니다. 자주 틀린 카드 복습이 필요합니다.`
+    );
+  }
+
+  // 2. 속도 관련
+  if (stats.timeDiffPercent > 0) {
+    messages.push(
+      `⏱️ 첫 세션(${stats.firstTime}초)보다 마지막 세션(${stats.lastTime}초)이 ${stats.timeDiffPercent}% 빨라졌습니다.`
+    );
+  } else if (stats.timeDiffPercent < 0) {
+    messages.push(
+      `🐢 첫 세션(${stats.firstTime}초) 대비 마지막 세션(${
+        stats.lastTime
+      }초)은 ${Math.abs(stats.timeDiffPercent)}% 느려졌습니다.`
+    );
+  } else {
+    messages.push(`⚖️ 첫 세션과 마지막 세션의 소요 시간이 비슷합니다.`);
+  }
+
+  // 3. 직전 대비 개선율
+  if (stats.improvementPercent !== null) {
+    if (stats.improvementPercent > 0) {
+      messages.push(
+        `📈 직전 세션 대비 ${stats.improvementPercent}% 빨라졌습니다.`
+      );
+    } else if (stats.improvementPercent < 0) {
+      messages.push(
+        `📉 직전 세션 대비 ${Math.abs(stats.improvementPercent)}% 느려졌습니다.`
+      );
+    }
+  }
+
+  // 4. 효율 관련
+  messages.push(
+    `⚡ 평균 ${stats.efficiency}개/초의 속도로 카드를 맞추고 있습니다. 목표는 0.5개/초 이상을 달성하는 것입니다.`
+  );
+
+  // 5. 세션 반복
+  if (stats.totalSessions > 1) {
+    messages.push(`🔄 총 ${stats.totalSessions}회 반복 학습을 진행했습니다.`);
+  } else {
+    messages.push(
+      `🆕 첫 세션을 완료했습니다. 반복 학습을 통해 더 빠른 개선이 기대됩니다.`
+    );
+  }
+
+  return messages;
+};


### PR DESCRIPTION
# 카드 맞추기 지표 통계 및 학습자 맞춤 피드백 feature 진행
## 🎯 게임 맞추기 통계 지표
### 세션별 비교
- 같은 세트를 반복할 때 소요 시간 감소 추세
- 세션별 정답률 향상 정도
### 학습자 맞춤 피드백
- “당신은 동의어 문제에는 강하지만 반의어 문제는 약합니다”
- “지난번보다 20% 빠르게 카드를 맞췄습니다”
- 학습자 맞춤 피드백에 대해서 사용자의 통계 지표에 따라 매핑하여 적절하게 피드백 문구 제공
### 게임 맞추기 통계 영역 추가
![게임 맞추기 통계 영역 화면 예시](https://github.com/user-attachments/assets/4050ad18-3bfd-4586-852b-05e7e3212e3a)
## TO-DO: 학습 지표 활용한 TO-USE 통계 지표
### 카드별 성과
- 카드별 정답률 (→ 학습자가 헷갈리는 카드 파악 가능)
- “이 세트에서 자주 틀린 카드 TOP 3” 등 카드별 성과에 따른 학습자 맞춤 피드백 제공
- 어떤 카드 쌍에서 오답이 발생했는지